### PR TITLE
Add home page for app collection

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>XMB Apps</title>
+    <link rel="stylesheet" href="Product-Config/styles/main.css">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header>
+        <div class="container">
+            <a href="https://www.xmbengineering.com/home" class="header-link">
+                <div class="titlelogo">
+                    <img src="Product-Config/images/XMB_logo.jpg" class="logo" role="img" aria-label="XMB Engineering">
+                    <h1 class="site-name">XMB</h1>
+                </div>
+            </a>
+            <div class="app-name">Apps</div>
+        </div>
+    </header>
+    <main>
+        <div id="configurator">
+            <a class="product" href="Product-Config/main.html">
+                <p>Product Configurator</p>
+            </a>
+            <a class="product" href="HexaPod-Sim/index.html">
+                <p>Hexapod Simulator</p>
+            </a>
+            <a class="product" href="PhotographyWeb/index.html">
+                <p>Photography Web</p>
+            </a>
+            <div class="product">
+                <p>More Coming Soon</p>
+            </div>
+        </div>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add root home page styled like Product Configurator to showcase available apps
- Include links to Product Configurator, Hexapod Simulator, and Photography Web with room for future apps

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68941c0077548333bbc4f81e810c15c6