### PR TITLE
Use manifest to list CSV files in Node_App

### DIFF
--- a/Node_App/data/csvFiles.json
+++ b/Node_App/data/csvFiles.json
@@ -1,0 +1,7 @@
+{
+  "files": [
+    "Book1.csv",
+    "Book2.csv"
+  ]
+}
+

--- a/Node_App/main.html
+++ b/Node_App/main.html
@@ -100,6 +100,7 @@
     <select id="csvSelector">
       <!-- Options will be populated dynamically -->
     </select>
+    <input type="file" id="csvUpload" accept=".csv">
   </div>
 
   <!-- Legend Section (Bottom Right) -->
@@ -183,149 +184,162 @@
       });
     svg.call(zoom);
 
-    // Function to compile a list of CSV files from the data folder.
-    // This relies on directory listing being enabled on the server.
+    // Function to retrieve the list of available CSV files.
+    // Directory listing is not available on this server, so we use a
+    // pre-generated JSON manifest that enumerates the files.
     function getCSVFileList() {
-      return fetch("data/").then(response => response.text()).then(htmlText => {
-        const parser = new DOMParser();
-        const doc = parser.parseFromString(htmlText, "text/html");
-        const links = Array.from(doc.querySelectorAll("a"));
-        // Filter links that do not end with "/" and end with ".csv", then remove any folder parts.
-        const csvFiles = links
-          .map(link => link.getAttribute("href"))
-          .filter(href => href && !href.endsWith("/") && href.toLowerCase().endsWith(".csv"))
-          .map(href => href.split("/").pop());
-        return csvFiles;
+      return fetch("data/csvFiles.json")
+        .then(response => {
+          if (!response.ok) {
+            throw new Error("Unable to load CSV file list");
+          }
+          return response.json();
+        })
+        .then(data => data.files || []);
+    }
+
+    // Core graph rendering logic reused by CSV sources
+    function renderCSVData(data) {
+      // Clear previous visualization
+      svgGroup.selectAll("*").remove();
+
+      const nodesMap = {};
+      const links = [];
+
+      data.forEach(function(d) {
+        // Create TAG node with NODE COLOR and NODE SIZE (defaults if missing)
+        if (!nodesMap[d.TAG]) {
+          nodesMap[d.TAG] = {
+            id: d.TAG,
+            color: d["NODE COLOR"] || "orange",
+            size: d["NODE SIZE"] ? +d["NODE SIZE"] : 10
+          };
+        }
+        // Create SOURCE node if defined; assign default color and size if not provided
+        if (d.SOURCE && !nodesMap[d.SOURCE]) {
+          nodesMap[d.SOURCE] = {
+            id: d.SOURCE,
+            color: "lightblue",
+            size: 10
+          };
+        }
+        // Only add a link if SOURCE is defined
+        if (d.SOURCE) {
+          links.push({
+            source: d.SOURCE,
+            target: d.TAG,
+            connection: d["CONNECTION COLOR"] || "#999",
+            text: d["CONNECTOR TEXT"] || ""
+          });
+        }
       });
+
+      const nodes = Object.values(nodesMap);
+
+      // Create force simulation
+      const simulation = d3.forceSimulation(nodes)
+        .force("link", d3.forceLink(links).id(d => d.id).distance(100))
+        .force("charge", d3.forceManyBody().strength(-200))
+        .force("center", d3.forceCenter(width / 2, height / 2));
+
+      // Add links
+      const link = svgGroup.append("g")
+          .attr("class", "links")
+        .selectAll("line")
+        .data(links)
+        .enter().append("line")
+          .attr("stroke-width", 2)
+          .attr("stroke", d => d.connection);
+
+      // Add connector text labels for each link (half the font size of node text)
+      const connectorLabels = svgGroup.append("g")
+          .attr("class", "connectorLabels")
+        .selectAll("text")
+        .data(links)
+        .enter().append("text")
+          .text(d => d.text)
+          .style("font-size", "5px");
+
+      // Add nodes
+      const node = svgGroup.append("g")
+          .attr("class", "nodes")
+        .selectAll("circle")
+        .data(nodes)
+        .enter().append("circle")
+          .attr("r", d => d.size)
+          .attr("fill", d => d.color)
+          .call(drag(simulation));
+
+      // Always-visible labels centered in nodes
+      const labels = svgGroup.append("g")
+          .attr("class", "labels")
+        .selectAll("text")
+        .data(nodes)
+        .enter().append("text")
+          .text(d => d.id);
+
+      simulation.on("tick", () => {
+        link
+          .attr("x1", d => d.source.x)
+          .attr("y1", d => d.source.y)
+          .attr("x2", d => d.target.x)
+          .attr("y2", d => d.target.y);
+
+        // Position connector labels at the midpoint of each link
+        connectorLabels
+          .attr("x", d => (d.source.x + d.target.x) / 2)
+          .attr("y", d => (d.source.y + d.target.y) / 2);
+
+        node
+          .attr("cx", d => d.x)
+          .attr("cy", d => d.y);
+
+        // Position node labels at the center of each node
+        labels
+          .attr("x", d => d.x)
+          .attr("y", d => d.y);
+      });
+
+      // Drag functions for nodes
+      function drag(simulation) {
+        function dragstarted(event, d) {
+          if (!event.active) simulation.alphaTarget(0.3).restart();
+          d.fx = d.x;
+          d.fy = d.y;
+        }
+        function dragged(event, d) {
+          d.fx = event.x;
+          d.fy = event.y;
+        }
+        function dragended(event, d) {
+          if (!event.active) simulation.alphaTarget(0);
+          d.fx = null;
+          d.fy = null;
+        }
+        return d3.drag()
+          .on("start", dragstarted)
+          .on("drag", dragged)
+          .on("end", dragended);
+      }
     }
 
     // Function to load and render CSV data given a filename
     function loadCSVData(filename) {
-      // Clear previous visualization
-      svgGroup.selectAll("*").remove();
-      
-      d3.csv("data/" + filename).then(function(data) {
-        const nodesMap = {};
-        const links = [];
-
-        data.forEach(function(d) {
-          // Create TAG node with NODE COLOR and NODE SIZE (defaults if missing)
-          if (!nodesMap[d.TAG]) {
-            nodesMap[d.TAG] = {
-              id: d.TAG,
-              color: d["NODE COLOR"] || "orange",
-              size: d["NODE SIZE"] ? +d["NODE SIZE"] : 10
-            };
-          }
-          // Create SOURCE node if defined; assign default color and size if not provided
-          if (d.SOURCE && !nodesMap[d.SOURCE]) {
-            nodesMap[d.SOURCE] = {
-              id: d.SOURCE,
-              color: "lightblue",
-              size: 10
-            };
-          }
-          // Only add a link if SOURCE is defined
-          if (d.SOURCE) {
-            links.push({
-              source: d.SOURCE,
-              target: d.TAG,
-              connection: d["CONNECTION COLOR"] || "#999",
-              text: d["CONNECTOR TEXT"] || ""
-            });
-          }
+      d3.csv("data/" + filename)
+        .then(renderCSVData)
+        .catch(function(error) {
+          console.error("Error loading CSV file:", error);
         });
+    }
 
-        const nodes = Object.values(nodesMap);
-
-        // Create force simulation
-        const simulation = d3.forceSimulation(nodes)
-          .force("link", d3.forceLink(links).id(d => d.id).distance(100))
-          .force("charge", d3.forceManyBody().strength(-200))
-          .force("center", d3.forceCenter(width / 2, height / 2));
-
-        // Add links
-        const link = svgGroup.append("g")
-            .attr("class", "links")
-          .selectAll("line")
-          .data(links)
-          .enter().append("line")
-            .attr("stroke-width", 2)
-            .attr("stroke", d => d.connection);
-
-        // Add connector text labels for each link (half the font size of node text)
-        const connectorLabels = svgGroup.append("g")
-            .attr("class", "connectorLabels")
-          .selectAll("text")
-          .data(links)
-          .enter().append("text")
-            .text(d => d.text)
-            .style("font-size", "5px");
-
-        // Add nodes
-        const node = svgGroup.append("g")
-            .attr("class", "nodes")
-          .selectAll("circle")
-          .data(nodes)
-          .enter().append("circle")
-            .attr("r", d => d.size)
-            .attr("fill", d => d.color)
-            .call(drag(simulation));
-
-        // Always-visible labels centered in nodes
-        const labels = svgGroup.append("g")
-            .attr("class", "labels")
-          .selectAll("text")
-          .data(nodes)
-          .enter().append("text")
-            .text(d => d.id);
-
-        simulation.on("tick", () => {
-          link
-            .attr("x1", d => d.source.x)
-            .attr("y1", d => d.source.y)
-            .attr("x2", d => d.target.x)
-            .attr("y2", d => d.target.y);
-
-          // Position connector labels at the midpoint of each link
-          connectorLabels
-            .attr("x", d => (d.source.x + d.target.x) / 2)
-            .attr("y", d => (d.source.y + d.target.y) / 2);
-
-          node
-            .attr("cx", d => d.x)
-            .attr("cy", d => d.y);
-
-          // Position node labels at the center of each node
-          labels
-            .attr("x", d => d.x)
-            .attr("y", d => d.y);
-        });
-
-        // Drag functions for nodes
-        function drag(simulation) {
-          function dragstarted(event, d) {
-            if (!event.active) simulation.alphaTarget(0.3).restart();
-            d.fx = d.x;
-            d.fy = d.y;
-          }
-          function dragged(event, d) {
-            d.fx = event.x;
-            d.fy = event.y;
-          }
-          function dragended(event, d) {
-            if (!event.active) simulation.alphaTarget(0);
-            d.fx = null;
-            d.fy = null;
-          }
-          return d3.drag()
-            .on("start", dragstarted)
-            .on("drag", dragged)
-            .on("end", dragended);
-        }
-      }).catch(function(error) {
-        console.error("Error loading CSV file:", error);
-      });
+    // Function to handle user-uploaded CSV text
+    function loadCSVText(csvText) {
+      try {
+        const data = d3.csvParse(csvText);
+        renderCSVData(data);
+      } catch (error) {
+        console.error("Error parsing uploaded CSV file:", error);
+      }
     }
 
     // Populate the CSV selector by fetching the list of CSV files from the data folder
@@ -351,6 +365,18 @@
       });
     }).catch(function(error) {
       console.error("Error retrieving CSV file list:", error);
+    });
+
+    // Handle user-uploaded CSV files
+    document.getElementById("csvUpload").addEventListener("change", function() {
+      const file = this.files[0];
+      if (file) {
+        const reader = new FileReader();
+        reader.onload = function(e) {
+          loadCSVText(e.target.result);
+        };
+        reader.readAsText(file);
+      }
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Replace directory listing logic with fetch of JSON manifest to list available CSV files.
- Add `csvFiles.json` manifest enumerating CSV files in Node_App data folder.
- Allow users to upload custom CSVs via file input, reusing core render logic.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68942b1cdc648333893706c0246a761c