### PR TITLE
Add header links to main site and apps page

### DIFF
--- a/src/header.html
+++ b/src/header.html
@@ -7,8 +7,13 @@
         <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap" rel="stylesheet">
         <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
     </head>
-    <div class="titlelogo">
-        <img src="../src/images/XMB_logo.jpg" class="logo" role="img" aria-label="XMB Engineering">
-        <h1 class="site-name"></h1>
+    <div class="container">
+        <div class="titlelogo">
+            <a href="https://www.xmbengineering.com" class="header-link">
+                <img src="../src/images/XMB_logo.jpg" class="logo" role="img" aria-label="XMB Engineering">
+            </a>
+            <h1 class="site-name"></h1>
+        </div>
+        <a href="https://apps.xmbengineering.com/src/index.html" class="app-name">Apps</a>
     </div>
 </header>


### PR DESCRIPTION
## Summary
- Wrap header logo in link to www.xmbengineering.com
- Add "Apps" navigation button in header pointing to apps portal

## Testing
- `npm test --prefix src`

------
https://chatgpt.com/codex/tasks/task_b_6895219da4048333a59a27ce5401f8ba