### PR TITLE
Display click-generated graphics on index page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -50,6 +50,6 @@
             });
         </script>
     </footer>
-    <script src="../src/scripts/background.js"></script>
+    <script src="scripts/background.js"></script>
 </body>
 </html>

--- a/src/scripts/background.js
+++ b/src/scripts/background.js
@@ -13,22 +13,37 @@ document.addEventListener('click', (event) => {
         const segment = document.createElement('div');
         segment.className = 'segment';
   
-        // Randomize the length and direction (only right angles)
-        const length = Math.random() * 30 + 30; // Random length between 20 and 70
+        // Randomize the direction (only right angles)
         const direction = Math.random() < 0.5 ? -90 : 90; // Turn left or right
         const angle = (previousAngle + direction + 360) % 360; // Ensure angles remain valid
-  
+
+        // Determine the maximum length that keeps the segment within bounds
+        let maxLength;
+        if (angle === 0) {
+          maxLength = window.innerWidth - currentX;
+        } else if (angle === 90) {
+          maxLength = window.innerHeight - currentY;
+        } else if (angle === 180) {
+          maxLength = currentX;
+        } else {
+          maxLength = currentY; // 270
+        }
+
+        if (maxLength <= 0) return;
+
+        const length = Math.min(Math.random() * 30 + 30, maxLength);
+
         segment.style.left = `${currentX}px`;
         segment.style.top = `${currentY}px`;
         segment.style.transform = `rotate(${angle}deg)`;
-  
+
         document.body.appendChild(segment);
-  
+
         // Trigger the growth animation after adding the element to the DOM
         setTimeout(() => {
           segment.style.width = `${length}px`;
         }, 0);
-  
+
         // Calculate the endpoint of the segment
         let endX = currentX;
         let endY = currentY;
@@ -36,19 +51,19 @@ document.addEventListener('click', (event) => {
         else if (angle === 90) endY += length; // Down
         else if (angle === 180) endX -= length; // Left
         else if (angle === 270) endY -= length; // Up
-  
+
         // Add a circle at the end of the segment
         const circle = document.createElement('div');
         circle.className = 'circle';
-        circle.style.left = `${endX - 3}px`; // Center the circle
-        circle.style.top = `${endY - 3}px`; // Center the circle
+        circle.style.left = `${Math.min(Math.max(endX - 3, 0), window.innerWidth - 6)}px`; // Keep within bounds
+        circle.style.top = `${Math.min(Math.max(endY - 3, 0), window.innerHeight - 6)}px`; // Keep within bounds
         document.body.appendChild(circle);
-  
+
         // Update the current position and angle for the next segment
         currentX = endX;
         currentY = endY;
         previousAngle = angle;
-  
+
         // Remove the segment and circle after the animation ends
         setTimeout(() => {
           segment.remove();

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -141,3 +141,31 @@ footer p {
     font-size: 0.9rem;
     font: 0.7em sans-serif;
 }
+
+/* Click effect graphics */
+@keyframes fadeOut {
+    to {
+        opacity: 0;
+    }
+}
+
+.segment {
+    position: absolute;
+    height: 4px;
+    width: 0;
+    background-color: #ffffff;
+    transform-origin: 0 50%;
+    pointer-events: none;
+    transition: width 0.3s ease;
+    animation: fadeOut 3.5s forwards;
+}
+
+.circle {
+    position: absolute;
+    width: 6px;
+    height: 6px;
+    background-color: #ffffff;
+    border-radius: 50%;
+    pointer-events: none;
+    animation: fadeOut 3.5s forwards;
+}


### PR DESCRIPTION
## Summary
- Load background click graphics script directly on the index page
- Add styles for segment and circle elements and fade animation for click effects
- Ensure click-generated segments and circles stay within the viewport bounds

## Testing
- `npm test --prefix src`


------
https://chatgpt.com/codex/tasks/task_b_68953c254b408333847653f276774ffe