### PR TITLE
feat: refresh PhotographyWeb color palette

### DIFF
--- a/PhotographyWeb/styles/main.css
+++ b/PhotographyWeb/styles/main.css
@@ -1,6 +1,6 @@
 body {
-  background-color: #000;
-  color: #fff;
+  background-color: #f8f9fa;
+  color: #333;
   font-family: sans-serif;
   margin: 0;
   padding: 2rem;
@@ -19,7 +19,7 @@ h1 {
 }
 
 p {
-  color: #ccc;
+  color: #555;
   margin-bottom: 2rem;
 }
 
@@ -30,20 +30,21 @@ p {
 }
 
 .card {
-  background: #1a1a1a;
+  background: #fff;
   border-radius: 12px;
   padding: 1.5rem;
   cursor: pointer;
   transition: box-shadow 0.3s;
+  color: #333;
 }
 
 .card:hover {
-  box-shadow: 0 0 10px rgba(255,255,255,0.2);
+  box-shadow: 0 0 10px rgba(0, 123, 255, 0.2);
 }
 
 .selected {
-  background: #fff;
-  color: #000;
+  background: #e9ecef;
+  color: #333;
   text-align: left;
   padding: 1.5rem;
   border-radius: 12px;
@@ -58,11 +59,16 @@ button {
   margin-top: 1rem;
   padding: 0.5rem 1rem;
   border: none;
-  background: #000;
+  background: #007bff;
   color: #fff;
   font-weight: bold;
   border-radius: 6px;
   cursor: pointer;
+  transition: background 0.3s;
+}
+
+button:hover {
+  background: #0056b3;
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
## Summary
- switch PhotographyWeb to a lighter color palette
- update card, selection, and button colors for cohesive theme

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689558fb391c8333b096a01069339334