### PR TITLE
Add hierarchy tree demos using multiple libraries

### DIFF
--- a/XMBTrak/assets/tree-demos.js
+++ b/XMBTrak/assets/tree-demos.js
@@ -1,0 +1,115 @@
+// Initialize various tree demos
+window.addEventListener('load', function(){
+  // jsTree example
+  if (typeof $ !== 'undefined' && $.fn.jstree) {
+    $('#jstree-demo').jstree({
+      'core' : {
+        'data' : [
+          { 'text' : 'Root node', 'children' : [
+            { 'text' : 'Child node 1' },
+            { 'text' : 'Child node 2' }
+          ]}
+        ]
+      },
+      'plugins' : ['checkbox']
+    });
+  }
+
+  // FancyTree example
+  if (typeof $ !== 'undefined' && $.fn.fancytree) {
+    $('#fancytree-demo').fancytree({
+      source: [
+        {title: 'Node 1', folder: true, children:[
+          {title: 'Child 1'},
+          {title: 'Child 2'}
+        ]},
+        {title: 'Node 2', children:[{title: 'Child 3'}]}
+      ]
+    });
+  }
+
+  // ag-Grid tree data example
+  if (typeof agGrid !== 'undefined') {
+    const gridOptions = {
+      columnDefs: [
+        { field: 'orgHierarchy', headerName: 'Hierarchy', cellRenderer: 'agGroupCellRenderer' }
+      ],
+      rowData: [
+        { orgHierarchy: ['A', 'A1'] },
+        { orgHierarchy: ['A', 'A2'] },
+        { orgHierarchy: ['B'] },
+        { orgHierarchy: ['B', 'B1'] }
+      ],
+      treeData: true,
+      animateRows: true,
+      groupDefaultExpanded: -1,
+      getDataPath: function(data){ return data.orgHierarchy; }
+    };
+    new agGrid.Grid(document.querySelector('#aggrid-demo'), gridOptions);
+  }
+
+  // Handsontable nested rows example
+  if (typeof Handsontable !== 'undefined') {
+    const hotData = [
+      {id:1, name:'Parent 1', __children:[
+        {id:2, name:'Child 1.1'},
+        {id:3, name:'Child 1.2'}
+      ]},
+      {id:4, name:'Parent 2'}
+    ];
+    new Handsontable(document.getElementById('handsontable-demo'), {
+      data: hotData,
+      colHeaders: ['ID', 'Name'],
+      columns: [{data:'id'}, {data:'name'}],
+      nestedRows: true,
+      rowHeaders: true,
+      licenseKey: 'non-commercial-and-evaluation'
+    });
+  }
+
+  // PrimeVue TreeTable example
+  if (typeof Vue !== 'undefined' && typeof PrimeVue !== 'undefined') {
+    const { createApp } = Vue;
+    const app = createApp({
+      data(){
+        return {
+          nodes: [
+            { key:'0', label:'Documents', children:[
+              { key:'0-0', label:'Work', children:[
+                { key:'0-0-0', label:'Expenses.doc' },
+                { key:'0-0-1', label:'Resume.doc' }
+              ]},
+              { key:'0-1', label:'Home', children:[
+                { key:'0-1-0', label:'Invoices.txt' }
+              ]}
+            ]}
+          ]
+        };
+      },
+      template:`<TreeTable :value="nodes">
+                  <Column field="label" header="Name" />
+                </TreeTable>`
+    });
+    app.use(PrimeVue);
+    app.component('TreeTable', PrimeVue.TreeTable);
+    app.component('Column', PrimeVue.Column);
+    app.mount('#primevue-tree');
+  }
+
+  // DevExtreme DataGrid tree data example
+  if (typeof $ !== 'undefined' && typeof $.fn.dxDataGrid !== 'undefined') {
+    $('#dxgrid-demo').dxDataGrid({
+      dataSource: [
+        { id:1, parentId:0, name:'Parent 1' },
+        { id:2, parentId:1, name:'Child 1.1' },
+        { id:3, parentId:1, name:'Child 1.2' },
+        { id:4, parentId:0, name:'Parent 2' }
+      ],
+      keyExpr: 'id',
+      parentIdExpr: 'parentId',
+      dataStructure: 'tree',
+      columns: ['name'],
+      showBorders: true
+    });
+  }
+});

--- a/XMBTrak/index.html
+++ b/XMBTrak/index.html
@@ -46,6 +46,21 @@
             <h2 class="title is-5">ag-Grid Tree Data Demo</h2>
             <div id="aggrid-demo" style="height:300px;width:100%;" class="ag-theme-alpine"></div>
           </div>
+
+          <div class="mt-5">
+            <h2 class="title is-5">Handsontable Tree Demo</h2>
+            <div id="handsontable-demo" style="width:600px;"></div>
+          </div>
+
+          <div class="mt-5">
+            <h2 class="title is-5">PrimeVue TreeTable Demo</h2>
+            <div id="primevue-tree"></div>
+          </div>
+
+          <div class="mt-5">
+            <h2 class="title is-5">DevExtreme DataGrid Tree Demo</h2>
+            <div id="dxgrid-demo" style="height:300px;"></div>
+          </div>
         </section>
 
 
@@ -80,6 +95,23 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@30.2.0/styles/ag-grid.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@30.2.0/styles/ag-theme-alpine.css" />
   <script src="https://cdn.jsdelivr.net/npm/ag-grid-community@30.2.0/dist/ag-grid-community.min.noStyle.js"></script>
+
+  <!-- Handsontable CSS & JS -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/handsontable@13.1.0/dist/handsontable.min.css" />
+  <script src="https://cdn.jsdelivr.net/npm/handsontable@13.1.0/dist/handsontable.min.js"></script>
+
+  <!-- PrimeVue CSS & JS -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/primevue@3.46.0/resources/themes/saga-blue/theme.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/primevue@3.46.0/resources/primevue.min.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/primeicons@6.0.1/primeicons.css" />
+  <script src="https://cdn.jsdelivr.net/npm/vue@3.3.4/dist/vue.global.prod.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/primevue@3.46.0/core/core.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/primevue@3.46.0/treetable/treetable.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/primevue@3.46.0/column/column.min.js"></script>
+
+  <!-- DevExtreme CSS & JS -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/devextreme@23.1.3/dist/css/dx.light.css" />
+  <script src="https://cdn.jsdelivr.net/npm/devextreme@23.1.3/dist/js/dx.all.js"></script>
   <!-- Simple HTML include script for header and footer -->
   <script>
     function includeHTML(id, url) {
@@ -108,6 +140,8 @@
   </script>
   <!-- Tabulator initialization script -->
   <script src="assets/tabulator-init.js"></script>
+  <!-- Tree libraries initialization script -->
+  <script src="assets/tree-demos.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add demo sections for jsTree, FancyTree, ag-Grid, Handsontable, PrimeVue TreeTable, and DevExtreme DataGrid
- wire up CDN assets for each library
- initialize demos with sample hierarchical data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae9354bfe08333b9bc1ddae90e4be4