### PR TITLE
Streamline tree demos and fix library initialization

### DIFF
--- a/XMBTrak/assets/tree-demos.js
+++ b/XMBTrak/assets/tree-demos.js
@@ -1,0 +1,92 @@
+// Initialize various tree demos
+window.addEventListener('load', function(){
+  // jsTree example
+  if (typeof $ !== 'undefined' && $.fn.jstree) {
+    $('#jstree-demo').jstree({
+      'core' : {
+        'data' : [
+          { 'text' : 'Root node', 'children' : [
+            { 'text' : 'Child node 1' },
+            { 'text' : 'Child node 2' }
+          ]}
+        ]
+      },
+      'plugins' : ['checkbox']
+    });
+  }
+
+  // FancyTree example with columns
+  if (typeof $ !== 'undefined' && $.fn.fancytree) {
+    $('#fancytree-demo').fancytree({
+      extensions: ['table'],
+      source: [
+        {
+          title: 'Node 1',
+          data: { info: 'Info 1' },
+          folder: true,
+          children: [
+            { title: 'Child 1', data: { info: 'Info 1.1' } },
+            { title: 'Child 2', data: { info: 'Info 1.2' } }
+          ]
+        },
+        { title: 'Node 2', data: { info: 'Info 2' } }
+      ],
+      table: {
+        indentation: 20,
+        nodeColumnIdx: 0
+      },
+      renderColumns: function(event, data) {
+        var node = data.node;
+        var $tdList = $(node.tr).find('>td');
+        $tdList.eq(1).text(node.data.info);
+      }
+    });
+  }
+
+  // PrimeVue TreeTable example
+  if (typeof Vue !== 'undefined' && typeof PrimeVue !== 'undefined') {
+    const { createApp } = Vue;
+    const app = createApp({
+      data(){
+        return {
+          nodes: [
+            { key:'0', label:'Documents', children:[
+              { key:'0-0', label:'Work', children:[
+                { key:'0-0-0', label:'Expenses.doc' },
+                { key:'0-0-1', label:'Resume.doc' }
+              ]},
+              { key:'0-1', label:'Home', children:[
+                { key:'0-1-0', label:'Invoices.txt' }
+              ]}
+            ]}
+          ]
+        };
+      },
+      template:`<TreeTable :value="nodes">
+                  <Column field="label" header="Name" />
+                </TreeTable>`
+    });
+    app.use(PrimeVue.default);
+    app.component('TreeTable', PrimeVue.TreeTable);
+    app.component('Column', PrimeVue.Column);
+    app.mount('#primevue-tree');
+  }
+
+  // DevExtreme DataGrid tree data example
+  if (typeof $ !== 'undefined' && typeof $.fn.dxDataGrid !== 'undefined') {
+    $('#dxgrid-demo').dxDataGrid({
+      dataSource: [
+        { id:1, parentId:0, name:'Parent 1' },
+        { id:2, parentId:1, name:'Child 1.1' },
+        { id:3, parentId:1, name:'Child 1.2' },
+        { id:4, parentId:0, name:'Parent 2' }
+      ],
+      keyExpr: 'id',
+      parentIdExpr: 'parentId',
+      dataStructure: 'tree',
+      rootValue: 0,
+      columns: ['name'],
+      showBorders: true
+    });
+  }
+});

--- a/XMBTrak/index.html
+++ b/XMBTrak/index.html
@@ -39,12 +39,26 @@
 
           <div class="mt-5">
             <h2 class="title is-5">FancyTree Demo</h2>
-            <div id="fancytree-demo"></div>
+            <table id="fancytree-demo" class="table is-fullwidth">
+              <colgroup>
+                <col />
+                <col />
+              </colgroup>
+              <thead>
+                <tr><th>Name</th><th>Info</th></tr>
+              </thead>
+              <tbody></tbody>
+            </table>
           </div>
 
           <div class="mt-5">
-            <h2 class="title is-5">ag-Grid Tree Data Demo</h2>
-            <div id="aggrid-demo" style="height:300px;width:100%;" class="ag-theme-alpine"></div>
+            <h2 class="title is-5">PrimeVue TreeTable Demo</h2>
+            <div id="primevue-tree"></div>
+          </div>
+
+          <div class="mt-5">
+            <h2 class="title is-5">DevExtreme DataGrid Tree Demo</h2>
+            <div id="dxgrid-demo" style="height:300px;"></div>
           </div>
         </section>
 
@@ -68,18 +82,28 @@
   <div id="footer-include"></div>
   <!-- Tabulator JS (CDN, use https, must be before initialization) -->
   <script src="https://cdn.jsdelivr.net/npm/tabulator-tables@5.4.4/dist/js/tabulator.min.js"></script>
+  <!-- jQuery and jQuery UI -->
+  <script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.13.2/jquery-ui.min.js"></script>
   <!-- jsTree CSS & JS -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jstree@3.3.12/dist/themes/default/style.min.css" />
   <script src="https://cdn.jsdelivr.net/npm/jstree@3.3.12/dist/jstree.min.js"></script>
   <!-- FancyTree CSS & JS -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jquery.fancytree@2.38.2/dist/skin-win8/ui.fancytree.min.css" />
-  <script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.13.2/jquery-ui.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/jquery.fancytree@2.38.2/dist/jquery.fancytree-all-deps.min.js"></script>
-  <!-- ag-Grid CSS & JS -->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@30.2.0/styles/ag-grid.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@30.2.0/styles/ag-theme-alpine.css" />
-  <script src="https://cdn.jsdelivr.net/npm/ag-grid-community@30.2.0/dist/ag-grid-community.min.noStyle.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/jquery.fancytree@2.38.2/dist/jquery.fancytree-all.min.js"></script>
+
+  <!-- PrimeVue CSS & JS -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/primevue@3.46.0/resources/themes/saga-blue/theme.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/primevue@3.46.0/resources/primevue.min.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/primeicons@6.0.1/primeicons.css" />
+  <script src="https://cdn.jsdelivr.net/npm/vue@3.3.4/dist/vue.global.prod.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/primevue@3.46.0/core/core.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/primevue@3.46.0/treetable/treetable.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/primevue@3.46.0/column/column.min.js"></script>
+
+  <!-- DevExtreme CSS & JS -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/devextreme@23.1.3/dist/css/dx.light.css" />
+  <script src="https://cdn.jsdelivr.net/npm/devextreme@23.1.3/dist/js/dx.all.js"></script>
   <!-- Simple HTML include script for header and footer -->
   <script>
     function includeHTML(id, url) {
@@ -108,6 +132,8 @@
   </script>
   <!-- Tabulator initialization script -->
   <script src="assets/tabulator-init.js"></script>
+  <!-- Tree libraries initialization script -->
+  <script src="assets/tree-demos.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- drop ag-Grid and Handsontable demos
- add column data to FancyTree example
- fix jsTree, PrimeVue TreeTable and DevExtreme DataGrid initialization

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae9354bfe08333b9bc1ddae90e4be4