### PR TITLE
Enable reordering of criteria in relocation app

### DIFF
--- a/src/relocation.html
+++ b/src/relocation.html
@@ -11,15 +11,7 @@
   <div class="container">
     <aside class="controls">
       <h2>Rank Characteristics</h2>
-      <label>Weather
-        <input type="range" min="0" max="10" value="5" id="weight-weather">
-      </label>
-      <label>Cost of Living
-        <input type="range" min="0" max="10" value="5" id="weight-col">
-      </label>
-      <label>Housing Costs
-        <input type="range" min="0" max="10" value="5" id="weight-housing">
-      </label>
+      <ol id="criteria-list"></ol>
       <button id="update">Update Ranking</button>
     </aside>
     <section class="results">


### PR DESCRIPTION
## Summary
- Replace unused weight sliders with a dynamic list for ranking criteria
- Allow criteria to be moved up or down using arrow buttons on the left panel

## Testing
- `npm test --prefix src`


------
https://chatgpt.com/codex/tasks/task_b_68c7462df41083339e22acc887c7617c